### PR TITLE
feat: Add initial value and expected rate setup for new fleets

### DIFF
--- a/src/FleetOrderBookPreSaleZeroRefV2.sol
+++ b/src/FleetOrderBookPreSaleZeroRefV2.sol
@@ -456,6 +456,16 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
         lastFleetFractionID = totalFleet;
         fleetFractioned[lastFleetFractionID] = true;
         totalFractions[lastFleetFractionID] = totalFractions[lastFleetFractionID] + fractions;
+        // container counter
+        totalFleetOrderPerContainer++;
+
+        
+        // set initial value
+        setFleetInitialValue(fractions * fleetFractionPrice, totalFleet);
+        // set expected rate
+        setFleetExpectedRate(fleetFractionRate, totalFleet);
+
+
         // set status
         setFleetOrderStatus(lastFleetFractionID, INIT);
         emit FleetOrderStatusChanged(lastFleetFractionID, INIT);
@@ -521,6 +531,16 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
         lastFleetFractionID = totalFleet;
         fleetFractioned[lastFleetFractionID] = true;
         totalFractions[lastFleetFractionID] = totalFractions[lastFleetFractionID] + overflowFractions;
+        // container counter
+        totalFleetOrderPerContainer++;
+
+        
+        // set initial value
+        setFleetInitialValue(fractions * fleetFractionPrice, totalFleet);
+        // set expected rate
+        setFleetExpectedRate(fleetFractionRate, totalFleet);
+
+
         // set status
         setFleetOrderStatus(lastFleetFractionID, INIT);
         emit FleetOrderStatusChanged(lastFleetFractionID, INIT);


### PR DESCRIPTION
Added calls to setFleetInitialValue and setFleetExpectedRate when creating new fleet fractions, ensuring each new fleet has its initial value and expected rate set. Also incremented totalFleetOrderPerContainer to track container count.