### PR TITLE
Fix: container start check for fleet fractions

### DIFF
--- a/src/FleetOrderBookPreSaleZeroRefV2.sol
+++ b/src/FleetOrderBookPreSaleZeroRefV2.sol
@@ -268,8 +268,7 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
 
     function startNextContainer() external onlyRole(SUPER_ADMIN_ROLE) {
         if (totalFleetOrderPerContainer < maxFleetOrderPerContainer) revert MaxFleetOrderPerContainerNotReached();
-        bool isFractioned = fleetFractioned[totalFleet];
-        if (isFractioned && totalFractions[totalFleet] < MAX_FLEET_FRACTION) revert MaxFleetOrderPerContainerNotReached();
+        if (totalFractions[lastFleetFractionID] < MAX_FLEET_FRACTION) revert MaxFleetOrderPerContainerNotReached();
         totalFleetContainerOrder++;
         totalFleetPerContainer[totalFleetContainerOrder] = maxFleetOrderPerContainer;
         totalFleetOrderPerContainer = 0;


### PR DESCRIPTION
Updated the startNextContainer function to check totalFractions for lastFleetFractionID instead of using fleetFractioned and totalFleet. This ensures the correct validation before starting the next container.