### PR TITLE
feat: Change visibility of fleet order mappings to private

### DIFF
--- a/src/FleetOrderBookPreSaleZeroRef.sol
+++ b/src/FleetOrderBookPreSaleZeroRef.sol
@@ -83,18 +83,22 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
     uint256 constant MAX_ORDER_MULTIPLE_FLEET = 3;
     
 
-    /// @notice Mapping to store the IRL fulfillment state of each 3-wheeler fleet order
-    mapping(uint256 => uint256) public fleetOrderStatus;
     /// @notice check if ERC20 is accepted for fleet orders
     mapping(address => bool) public fleetERC20;
+    
+
+    /// @notice Mapping to store the IRL fulfillment state of each 3-wheeler fleet order
+    mapping(uint256 => uint256) private fleetOrderStatus;
     /// @notice owner => list of fleet order IDs
     mapping(address => uint256[]) private fleetOwned;
     /// @notice fleet order ID => list of owners
     mapping(uint256 => address[]) private fleetOwners;
-    /// @notice Total fractions of a token representing a 3-wheeler.
-    mapping(uint256 => bool) public fleetFractioned;
+    /// @notice checks if a token representing a 3-wheeler is fractioned.
+    mapping(uint256 => bool) private fleetFractioned;
     /// @notice Total fractions of a token representing a 3-wheeler.
     mapping(uint256 => uint256) private totalFractions;
+    /// @notice Total fleet orders per container.
+    mapping(uint256 => uint256) private totalFleetPerContainer;
     /// @notice tracking fleet order index for each owner
     mapping(address => mapping(uint256 => uint256)) private fleetOwnedIndex;
     /// @notice tracking owners index for each fleet order


### PR DESCRIPTION
Updated the visibility of fleetOrderStatus and fleetFractioned mappings from public to private for better encapsulation. Also added a new private mapping totalFleetPerContainer to track total fleet orders per container.