### PR TITLE
feat: Add getter functions for fleet order details

### DIFF
--- a/src/FleetOrderBookPreSale.sol
+++ b/src/FleetOrderBookPreSale.sol
@@ -618,7 +618,36 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, Ownable, Pausabl
     /// @param id The id of the fleet order.
     /// @return The addresses sharing the fleet id.
     function getFleetOwners(uint256 id) external view returns (address[] memory) {
+        if (id == 0) revert InvalidId();
+        if (id > totalFleet) revert IdDoesNotExist();
         return fleetOwners[id];
+    }
+
+
+    /// @notice Get the fleet order status of a fleet order.
+    /// @param id The id of the fleet order.
+    /// @return The fleet order status of the fleet order.
+    function getFleetOrderStatus(uint256 id) external view returns (uint256) {
+        if (id == 0) revert InvalidId();
+        if (id > totalFleet) revert IdDoesNotExist();
+        return fleetOrderStatus[id];
+    }
+
+
+    function getFleetFractioned(uint256 id) external view returns (bool) {
+        if (id == 0) revert InvalidId();
+        if (id > totalFleet) revert IdDoesNotExist();
+        return fleetFractioned[id];
+    }
+
+
+    /// @notice Get the total fractions of a fleet order.
+    /// @param id The id of the fleet order.
+    /// @return The total fractions of the fleet order.
+    function getTotalFractions(uint256 id) external view returns (uint256) {
+        if (id == 0) revert InvalidId();
+        if (id > totalFleet) revert IdDoesNotExist();
+        return totalFractions[id];
     }
 
 
@@ -711,7 +740,7 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, Ownable, Pausabl
     /// @notice Get the current status of a fleet order
     /// @param id The id of the fleet order to get the status for
     /// @return string The human-readable status string
-    function getFleetOrderStatus(uint256 id) public view returns (string memory) {
+    function getFleetOrderStatusReadable(uint256 id) public view returns (string memory) {
         if (id == 0) revert InvalidId();
         if (id > totalFleet) revert IdDoesNotExist();
         uint256 status = fleetOrderStatus[id];


### PR DESCRIPTION
Introduced new external view functions to retrieve fleet order status, fractioned state, and total fractions by ID, with input validation. Renamed the existing getFleetOrderStatus to getFleetOrderStatusReadable to avoid naming conflicts.