### PR TITLE
feat: Remove getTotalFractions function from contract

### DIFF
--- a/src/FleetOrderBookPreSaleZeroRefV2.sol
+++ b/src/FleetOrderBookPreSaleZeroRefV2.sol
@@ -713,16 +713,6 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
     }
 
 
-    /// @notice Get the total fractions of a fleet order.
-    /// @param id The id of the fleet order.
-    /// @return The total fractions of the fleet order.
-    function getTotalFractions(uint256 id) external view returns (uint256) {
-        if (id == 0) revert InvalidId();
-        if (id > totalFleet) revert IdDoesNotExist();
-        return totalFractions[id];
-    }
-
-
     /// @notice Get the total fleet per container of a fleet order.
     /// @param id The id of the fleet order.
     /// @return The total fleet per container of the fleet order.


### PR DESCRIPTION
Deleted the getTotalFractions(uint256) external view function, which returned the total fractions of a fleet order. This change may be for code cleanup or to restrict access to this data.