### PR TITLE
feat: Add setter for FleetOrderYield contract and update interface docs

### DIFF
--- a/src/FleetOrderBookPreSaleZeroRefV2.sol
+++ b/src/FleetOrderBookPreSaleZeroRefV2.sol
@@ -293,6 +293,12 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
     }
 
 
+    function setFleetOrderYieldContract(address _fleetOrderYieldContract) external onlyRole(SUPER_ADMIN_ROLE) {
+        if (_fleetOrderYieldContract == address(0)) revert InvalidAddress();
+        fleetOrderYieldContract = IFleetOrderYield(_fleetOrderYieldContract);
+    }
+
+
     /// @notice Set the compliance.
     /// @param owners The addresses to set as compliant.
     function setCompliance(address[] calldata owners) external onlyRole(COMPLIANCE_ROLE) {

--- a/src/interfaces/IFleetOrderYield.sol
+++ b/src/interfaces/IFleetOrderYield.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-/// @title 3wb.club fleet order book interface V1.0
-/// @notice interface for pre-orders for fractional and full investments in 3-wheelers
+/// @title 3wb.club fleet order yield interface V1.0
+/// @notice interface for yields for fractional and full investments in 3-wheelers
 /// @author Geeloko
 
 interface IFleetOrderYield {


### PR DESCRIPTION
Introduced setFleetOrderYieldContract function in FleetOrderBookPreSaleZeroRefV2 to allow SUPER_ADMIN to update the FleetOrderYield contract address. Also updated the IFleetOrderYield interface documentation to clarify its purpose.