### PR TITLE
feat: Fix initial fleet value calculation in pre-sale contract

### DIFF
--- a/src/FleetOrderBookPreSaleZeroRefV2.sol
+++ b/src/FleetOrderBookPreSaleZeroRefV2.sol
@@ -472,7 +472,7 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
 
         
         // set initial value
-        setFleetInitialValuePerOrder(fractions * fleetFractionPrice, totalFleet);
+        setFleetInitialValuePerOrder(MAX_FLEET_FRACTION * fleetFractionPrice, totalFleet);
         // set protocol expected rate
         setFleetProtocolExpectedValuePerOrder(fleetProtocolExpectedValue, totalFleet);
         // set liquidity provider expected rate
@@ -548,7 +548,7 @@ contract FleetOrderBookPreSale is IERC6909TokenSupply, ERC6909, AccessControl, P
 
         
         // set initial value
-        setFleetInitialValuePerOrder(fractions * fleetFractionPrice, totalFleet);
+        setFleetInitialValuePerOrder(MAX_FLEET_FRACTION * fleetFractionPrice, totalFleet);
         // set protocol expected rate
         setFleetProtocolExpectedValuePerOrder(fleetProtocolExpectedValue, totalFleet);
         // set liquidity provider expected rate


### PR DESCRIPTION
Replaces the use of 'fractions' with 'MAX_FLEET_FRACTION' when setting the initial fleet value per order, ensuring the calculation uses the maximum allowed fraction. This change affects both relevant functions to maintain consistency.